### PR TITLE
Added end to end tests to Picatrix

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -1,0 +1,16 @@
+name: picatrix-end-to-end
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up infrastructure with docker-compose
+        run: docker-compose -f docker/docker-compose.yml --env-file docker/config.env up -d
+        env:
+          JUPYTER_PORT: 8899
+      - name: Run e2e tests
+        run: docker-compose -f docker/docker-compose.yml --env-file docker/config.env exec -e PYTHONPATH="." -w /usr/local/src/picatrix -T picatrix /home/picatrix/picenv/bin/python /usr/local/src/picatrix/end_to_end_tests/tools/run_in_container.py
+

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,4 +27,4 @@ jobs:
         pip install -e .
     - name: Run pylint on picatrix and tests
       run: |
-        pipenv run pylint --rcfile=.pylintrc setup.py picatrix
+        pipenv run pylint --rcfile=.pylintrc setup.py picatrix end_to_end_tests

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to other services, etC).
 Read the [installation instructions](docs/Installation.md) on the best ways
 to install picatrix.
 
-After installing connect to the Jupyter notebook in your web browser (should open
+After installing, connect to the Jupyter notebook in your web browser (should open
 up automatically). Inside the notebook you need to import the picatrix library
 and initialize it:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/picatrix/blob/main/notebooks/Quick_Primer_on_Colab_Jupyter.ipynb)
 
-Picatrix is a framework that is meant to be used within a [Colab](https://colab.research.google.com) or 
+Picatrix is a framework that is meant to be used within a [Colab](https://colab.research.google.com) or
 [Jupyter](https://jupyter.org/) notebooks. The framework is designed around
 providing a security analyst with the libraries to develop helper functions
 that will be exposed as magics and regular python functions in notebooks.
@@ -17,26 +17,20 @@ to other services, etC).
 
 ## Howto Get Started
 
-The easiest way to get started is to create a virtualenv, eg:
+Read the [installation instructions](docs/Installation.md) on the best ways
+to install picatrix.
 
-```shell
-$ virtualenv picatrix_env
-$ source picatrix_env/bin/activate
-$ pip install picatrix
-```
-
-Then to start jupyter:
-```shell
-$ jupyter notebook
-```
-
-Connect to the Jupyter notebook in your web browser (should open up automatically).
-Inside the notebook you need to import the picatrix library and initialize it:
+After installing connect to the Jupyter notebook in your web browser (should open
+up automatically). Inside the notebook you need to import the picatrix library
+and initialize it:
 
 ```
 from picatrix import notebook_init
 notebook_init.init()
 ```
+
+(if you are using the docker container you don't need to import these libraries,
+that is done for you automatically).
 
 And that's it, then all the magics/helper functions are now ready and accessible
 to your notebook. To get a list of the available helpers, use:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,8 @@ RUN echo 'debconf debconf/frontend select Dialog' | debconf-set-selections
 # Create folders and fix permissions.
 RUN useradd picatrix -d /home/picatrix -m
 RUN mkdir -p /usr/local/src/picadata/notebooks
-RUN chmod 755 /usr/local/src/picadata/notebooks
+RUN chmod 777 /usr/local/src/picadata/
+RUN chmod 777 /usr/local/src/picadata/notebooks
 RUN find /usr/local/src/picadata/notebooks -type d -exec chmod 777 {} \;
 RUN find /usr/local/src/picadata/notebooks -type f -exec chmod 644 {} \;
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.6'
 services:
   picatrix:
     env_file:
@@ -12,4 +12,5 @@ services:
     volumes:
       - ../notebooks/:/usr/local/src/picadata/notebooks
       - /tmp/:/usr/local/src/picadata/data/
+      - ../:/usr/local/src/picatrix/:ro
 

--- a/docker/docker-latest.yml
+++ b/docker/docker-latest.yml
@@ -1,0 +1,14 @@
+version: '3.6'
+services:
+  picatrix:
+    image: us-docker.pkg.dev/osdfir-registry/picatrix/picatrix:latest
+    env_file:
+      - config.env
+    ports:
+      - "${JUPYTER_PORT}:${JUPYTER_PORT}"
+    restart: on-failure
+    volumes:
+      - ../notebooks/:/usr/local/src/picadata/notebooks
+      - /tmp/:/usr/local/src/picadata/data/
+      - ../:/usr/local/src/picatrix/:ro
+

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -49,8 +49,6 @@ To install picatrix using virtualenv you can use the following commands:
 $ python3 -m venv picatrix_env
 $ source picatrix_env/bin/activate
 $ pip install picatrix
-$ pip install jupyter_http_over_ws
-$ jupyter serverextension enable --py jupyter_http_over_ws
 ```
 
 And then to start picatrix you can either run:
@@ -59,7 +57,15 @@ And then to start picatrix you can either run:
 $ jupyter notebook
 ```
 
-Or if you want to connect from a colab frontend:
+If you want to connect from a colab frontend, then you'll need to run these
+two commands as well:
+
+```shell
+$ pip install jupyter_http_over_ws
+$ jupyter serverextension enable --py jupyter_http_over_ws
+```
+
+And then to run the notebook:
 
 ```shell
 $ jupyter notebook \

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,19 +1,28 @@
-# Docker
+# Installation
 
-Picatrix can be run as a docker image. To use it, first
+Picatrix can be installed via two ways:
+
+1. docker
+2. pip inside a virtualenv
+
+Let's explore both methods:
+
+## Docker
+
+The easiest way to install picatrix is via docker. To use it, first
 [install docker](https://docs.docker.com/engine/install/). You may also want to
 make sure you can run docker [sudo-less](https://docs.docker.com/engine/install/linux-postinstall/).
 
-To get picatrix up and running on docker (from source files):
+To run the docker container use:
 
 ```shell
 $ git clone https://github.com/google/picatrix.git
 $ cd picatrix/docker
-$ sudo docker-compose --env-file config.env up -d
+$ sudo docker-compose -f docker-latest.yml --env-file config.env up -d
 ```
 
-That will build and deploy the picatrix docker container. To be able to connect
-to picatrix in a jupyter shell, run:
+That will download the latest build and deploy the picatrix docker container.
+To be able to connect to picatrix in a jupyter shell, run:
 
 ```shell
 $ CONTAINER_ID=`sudo docker container list | grep docker_picatrix | awk '{print $1}'`
@@ -31,7 +40,37 @@ Copy the URL that starts with `http://127.0.0.....` and paste it into a browser
 window and you should have a fully working copy of Jupyter running, with an
 active picatrix library.
 
-You can confirm that by creating a new notebook and type in:
+
+## Virtualenv
+
+To install picatrix using virtualenv you can use the following commands:
+
+```shell
+$ python3 -m venv picatrix_env
+$ source picatrix_env/bin/activate
+$ pip install picatrix
+$ pip install jupyter_http_over_ws
+$ jupyter serverextension enable --py jupyter_http_over_ws
+```
+
+And then to start picatrix you can either run:
+
+```shell
+$ jupyter notebook
+```
+
+Or if you want to connect from a colab frontend:
+
+```shell
+$ jupyter notebook \
+  --NotebookApp.allow_origin='https://colab.research.google.com' \
+  --port=8888 \
+  --NotebookApp.port_retries=0
+```
+
+## Confirm Installation
+
+You can confirm the successful installation by creating a new notebook and type in:
 ```
 %picatrixmagics
 ```
@@ -48,17 +87,3 @@ that was provided from:
 Then select the arrow next to the `Connect` button, select `Connect to local
 runtime` and type in the URL with the token value into the `Backend URL`
 field and hit `CONNECT`.
-
-## Rebuild
-
-If you make changes to the dockerfiles please run:
-
-```shell
-sudo docker-compose --env-file config.env build
-```
-
-Before:
-
-```shell
-$ sudo docker-compose --env-file config.env up -d
-```

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -10,8 +10,7 @@ Let's explore both methods:
 ## Docker
 
 The easiest way to install picatrix is via docker. To use it, first
-[install docker](https://docs.docker.com/engine/install/). You may also want to
-make sure you can run docker [sudo-less](https://docs.docker.com/engine/install/linux-postinstall/).
+[install docker](https://docs.docker.com/engine/install/).
 
 To run the docker container use:
 

--- a/end_to_end_tests/__init__.py
+++ b/end_to_end_tests/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End to end test module."""
+
+# Register all tests by importing them.
+from . import basic_test

--- a/end_to_end_tests/basic_test.py
+++ b/end_to_end_tests/basic_test.py
@@ -1,0 +1,35 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End to end tests of common picatrix magics."""
+
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+
+from . import interface
+from . import manager
+
+
+class BasicTest(interface.BaseEndToEndTest):
+  """End to end tests for query functionality."""
+
+  NAME = 'basic_test'
+
+  def test_picatrixmagics(self, ip: TerminalInteractiveShell):
+    """Test the picatrixmagics."""
+    magics = ip.run_line_magic(magic_name='picatrixmagics', line='')
+
+    self.assertions.assertFalse(magics.empty)
+    self.assertions.assertTrue(magics.shape[0] > 10)
+
+
+manager.EndToEndTestManager.register_test(BasicTest)

--- a/end_to_end_tests/interface.py
+++ b/end_to_end_tests/interface.py
@@ -1,0 +1,90 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interface for end-to-end tests."""
+
+from typing import Callable
+from typing import Generator
+from typing import Text
+from typing import Tuple
+
+import unittest
+import inspect
+import collections
+import logging
+
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from IPython.testing.globalipapp import start_ipython
+
+
+logger = logging.getLogger('picatrix.e2e_test')
+
+# Default values based on Docker config.
+TEST_DATA_DIR = '/usr/local/src/picatrix/end_to_end_tests/test_data'
+
+
+class BaseEndToEndTest:
+  """Base class for end to end tests.
+
+  Attributes:
+      assertions: Instance of unittest.TestCase
+  """
+  assertions: unittest.TestCase
+
+  NAME = 'name'
+
+  def __init__(self):
+    """Initialize the end-to-end test object."""
+    self.assertions = unittest.TestCase()
+    self._counter = collections.Counter()
+
+  def _get_test_methods(self) -> Generator[
+      Tuple[Text, Callable[[TerminalInteractiveShell], None]], None, None]:
+    """Inspect class and list all methods that matches the criteria.
+
+    Yields:
+        Function name and bound method.
+    """
+    for name, func in inspect.getmembers(self, predicate=inspect.ismethod):
+      if name.startswith('test_'):
+        yield name, func
+
+  def setup(self):
+    """Setup function that is run before any tests.
+
+    This is a good place to import any data that is needed.
+    """
+
+  def run_tests(self) -> collections.Counter:
+    """Run all test functions from the class.
+
+    Returns:
+        Counter of number of tests and errors.
+    """
+    ip = start_ipython()
+    ip.run_cell(raw_cell='from picatrix import notebook_init')
+    ip.run_cell(raw_cell='notebook_init.init()')
+
+    logger.info('*** %s ***', self.NAME)
+    for test_name, test_func in self._get_test_methods():
+      self._counter['tests'] += 1
+      logger.info('Running test: %s ...', test_name)
+      try:
+        test_func(ip)
+      except Exception:  # pylint: disable=broad-except
+        logger.error(
+            'Error while running test %s', self.NAME, exc_info=True)
+        self._counter['errors'] += 1
+        continue
+      logger.info('%s [OK]', test_name)
+    return self._counter

--- a/end_to_end_tests/manager.py
+++ b/end_to_end_tests/manager.py
@@ -1,0 +1,92 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This file contains a class for managing end to end tests."""
+from typing import Generator
+from typing import Tuple
+from typing import Text
+
+from . import interface
+
+
+class EndToEndTestManager:
+  """The test manager."""
+
+  _class_registry: dict = {}
+  _exclude_registry: set = set()
+
+  @classmethod
+  def get_tests(cls) -> Generator[
+      Tuple[Text, interface.BaseEndToEndTest], None, None]:
+    """Retrieves the registered tests.
+
+    Yields:
+        tuple: containing:
+            unicode: the uniquely identifying name of the test
+            type: the test class.
+    """
+    for test_name, test_class in iter(cls._class_registry.items()):
+      if test_name in cls._exclude_registry:
+        continue
+      yield test_name, test_class
+
+  @classmethod
+  def get_test(cls, test_name: Text) -> interface.BaseEndToEndTest:
+    """Retrieves a class object of a specific test.
+
+    Args:
+        test_name (str): name of the test to retrieve.
+
+    Returns:
+        Instance of Test class object.
+
+    Raises:
+        KeyError: if the test is not registered.
+    """
+    try:
+      test_class = cls._class_registry[test_name.lower()]
+    except KeyError as exc:
+      raise KeyError(
+          'No such test type: {0:s}'.format(test_name.lower())) from exc
+    return test_class
+
+  @classmethod
+  def register_test(
+      cls, test_class: interface.BaseEndToEndTest,
+      exclude_from_list: bool = False):
+    """Registers an test class.
+
+    The test classes are identified by their lower case name.
+
+    Args:
+        test_class (type): the test class to register.
+        exclude_from_list (boolean): if set to True then the test
+            gets registered but will not be included in the
+            get_tests function. Defaults to False.
+
+    Raises:
+        KeyError: if class is already set for the corresponding name.
+    """
+    test_name = test_class.NAME.lower()
+    if test_name in cls._class_registry:
+      raise KeyError('Class already set for name: {0:s}.'.format(
+          test_class.NAME))
+    cls._class_registry[test_name] = test_class
+    if exclude_from_list:
+      cls._exclude_registry.add(test_name)
+
+  @classmethod
+  def clear_registration(cls):
+    """Clears all test registrations."""
+    cls._class_registry = {}
+    cls._exclude_registry = set()

--- a/end_to_end_tests/manager.py
+++ b/end_to_end_tests/manager.py
@@ -32,7 +32,7 @@ class EndToEndTestManager:
 
     Yields:
         tuple: containing:
-            unicode: the uniquely identifying name of the test
+            str: the uniquely identifying name of the test
             type: the test class.
     """
     for test_name, test_class in iter(cls._class_registry.items()):

--- a/end_to_end_tests/tools/run_in_container.py
+++ b/end_to_end_tests/tools/run_in_container.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to run all end to end tests."""
+
+import time
+from collections import Counter
+
+from end_to_end_tests import manager as test_manager
+
+manager = test_manager.EndToEndTestManager()
+counter = Counter()
+
+
+if __name__ == '__main__':
+  # Sleep to make sure all containers are operational
+  time.sleep(30)  # seconds
+
+  for name, cls in manager.get_tests():
+    test_class = cls()
+    # Prepare the test environment.
+    test_class.setup()
+    # Run all tests.
+    run_counter = test_class.run_tests()
+    counter['tests'] += run_counter['tests']
+    counter['errors'] += run_counter['errors']
+
+  successful_tests = counter['tests'] - counter['errors']
+  print('{0:d} total tests: {1:d} successful and {2:d} failed'.format(
+      counter['tests'], successful_tests, counter['errors']))


### PR DESCRIPTION
Fixes #10 

This PR adds end to end tests to picatrix using the docker container.

This PR introduces the e2e framework for picatrix. Now we can run tests with the fully setup docker container of picatrix to test various aspects of the tool. There is only a small POC test that is there for now, but more tests should be added.

In addition to that the documentation was changed slightly, renaming the docker.md to installation.md and adding information about the use of virtualenv in addition to the docker config.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR