### PR TITLE
Changed Dockerfile to use a slimmer image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,48 +1,29 @@
 # Use the official Docker Hub Ubuntu 18.04 base image
-FROM ubuntu:20.04
-
-# Workaround for bug in setuptools v50.
-# Ref: https://github.com/pypa/setuptools/issues/2350
-ENV SETUPTOOLS_USE_DISTUTILS=stdlib
-ENV JUPYTER_PORT=${JUPYTER_PORT}
+#FROM ubuntu:20.04
+FROM python:3.8-slim
 
 # Prevent needing to configure debian packages, stopping the setup of
 # the docker container.
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    software-properties-common \
-    python3-virtualenv \
-    python3-venv \
-    python3-pip \
-    python3-wheel \
-    python3-setuptools \
-    python3-psycopg2 \
-    git \
-    wget \
+RUN apt-get update && apt-get install -y --no-install-recommends git \
   && rm -rf /var/lib/apt/lists/*
 
-RUN echo 'debconf debconf/frontend select Dialog' | debconf-set-selections
-
 # Create folders and fix permissions.
-RUN useradd picatrix -d /home/picatrix -m
-RUN mkdir -p /usr/local/src/picadata/notebooks
-RUN chmod 777 /usr/local/src/picadata/
-RUN chmod 777 /usr/local/src/picadata/notebooks
-RUN find /usr/local/src/picadata/notebooks -type d -exec chmod 777 {} \;
-RUN find /usr/local/src/picadata/notebooks -type f -exec chmod 644 {} \;
+RUN useradd picatrix -d /home/picatrix -m && mkdir -p /usr/local/src/picadata/notebooks && \
+    chmod 777 /usr/local/src/picadata/ && \
+    chmod 777 /usr/local/src/picadata/notebooks && \
+    find /usr/local/src/picadata/notebooks -type d -exec chmod 777 {} \; && \
+    find /usr/local/src/picadata/notebooks -type f -exec chmod 644 {} \; 
 
 USER picatrix
 WORKDIR /home/picatrix
-# TODO: Enable this after fixing permission issues with the runtime file.
-# RUN mkdir -p .local/share/jupyter/runtime/
 RUN mkdir -p .ipython/profile_default/startup/
 
 USER root
+#RUN pip install virtualenv
 COPY docker/00-import.py /home/picatrix/.ipython/profile_default/startup/00-import.py
 RUN chown picatrix /home/picatrix/.ipython/profile_default/startup/00-import.py
-# TODO: Enable this after fixing permission issues with the runtime file.
-# RUN chmod 777 /home/picatrix/.local/share/jupyter/runtime/
 USER picatrix
 
 ENV VIRTUAL_ENV=/home/picatrix/picenv
@@ -50,15 +31,15 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install picatrix.
-RUN pip install wheel
-RUN pip install --upgrade picatrix
-RUN pip install jupyter_http_over_ws
-RUN jupyter serverextension enable --py jupyter_http_over_ws
+RUN pip install --upgrade pip setuptools wheel && \
+    pip install --upgrade picatrix jupyter_http_over_ws && \
+    jupyter serverextension enable --py jupyter_http_over_ws
 
 WORKDIR /usr/local/src/picadata/
+ENV JUPYTER_PORT=${JUPYTER_PORT}
 EXPOSE ${JUPYTER_PORT}
 
 # Run jupyter.
 CMD jupyter notebook --port ${JUPYTER_PORT} \ 
-	--NotebookApp.allow_origin='https://colab.research.google.com' \ 
-	--NotebookApp.port_retries=0 --ip '*'
+    --NotebookApp.allow_origin='https://colab.research.google.com' \ 
+    --NotebookApp.port_retries=0 --ip '*'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /home/picatrix
 RUN mkdir -p .ipython/profile_default/startup/
 
 USER root
-#RUN pip install virtualenv
 COPY docker/00-import.py /home/picatrix/.ipython/profile_default/startup/00-import.py
 RUN chown picatrix /home/picatrix/.ipython/profile_default/startup/00-import.py
 USER picatrix

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,8 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 COPY --chown=1000:1000 . /home/picatrix/code
-RUN cd code && pip install -e . && \
-    pip install --upgrade pip setuptools wheel && \
+RUN pip install --upgrade pip setuptools wheel && \
+    cd /home/picatrix/code && pip install -e . && \
     pip install --upgrade jupyter_http_over_ws && \
     jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,9 @@
 FROM python:3.8-slim
 
-# Prevent needing to configure debian packages, stopping the setup of
-# the docker container.
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-
-RUN apt-get update && apt-get install -y --no-install-recommends git \
-  && rm -rf /var/lib/apt/lists/*
-
 # Create folders and fix permissions.
-RUN useradd picatrix -d /home/picatrix -m && mkdir -p /usr/local/src/picadata/notebooks && \
+RUN groupadd --gid 1000 picagroup && \
+    useradd picatrix --uid 1000 --gid 1000 -d /home/picatrix -m && \
+    mkdir -p /usr/local/src/picadata/notebooks && \
     chmod 777 /usr/local/src/picadata/ && \
     chmod 777 /usr/local/src/picadata/notebooks && \
     find /usr/local/src/picadata/notebooks -type d -exec chmod 777 {} \; && \
@@ -27,9 +22,10 @@ ENV VIRTUAL_ENV=/home/picatrix/picenv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Install picatrix.
-RUN pip install --upgrade pip setuptools wheel && \
-    pip install --upgrade picatrix jupyter_http_over_ws && \
+COPY --chown=1000:1000 . /home/picatrix/code
+RUN cd code && pip install -e . && \
+    pip install --upgrade pip setuptools wheel && \
+    pip install --upgrade jupyter_http_over_ws && \
     jupyter serverextension enable --py jupyter_http_over_ws
 
 WORKDIR /usr/local/src/picadata/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,3 @@
-# Use the official Docker Hub Ubuntu 18.04 base image
-#FROM ubuntu:20.04
 FROM python:3.8-slim
 
 # Prevent needing to configure debian packages, stopping the setup of

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -74,6 +74,13 @@ folder of the container (which is mapped to a folder on the host).
 To upgrade the container using the latest build, you can run:
 
 ```shell
+$ sudo docker-compose -f docker-latest.yml --env-file config.env pull
+$ sudo docker-compose -f docker-latest.yml --env-file config.env up -d
+```
+
+You can also manually pull the new image using:
+
+```shell
 $ sudo docker pull us-docker.pkg.dev/osdfir-registry/picatrix/picatrix:latest
 ```
 
@@ -88,12 +95,6 @@ commands are executed. If you want the notebooks to survive, make sure
 that the notebooks are stored on the host (which means to store them in
 the data folder in the container, which is mapped to a directory on the
 host itself).*
-
-```shell
-$ sudo docker stop docker_picatrix_1 && sudo docker rm docker_picatrix_1
-$ cd picatrix/docker
-$ sudo docker-compose -f docker-latest.yml --env-file config.env up -d
-```
 
 ## Virtualenv
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -90,8 +90,7 @@ the data folder in the container, which is mapped to a directory on the
 host itself).*
 
 ```shell
-$ sudo docker stop docker_picatrix_1
-$ sudo docker rm docker_picatrix_1
+$ sudo docker stop docker_picatrix_1 && sudo docker rm docker_picatrix_1
 $ cd picatrix/docker
 $ sudo docker-compose -f docker-latest.yml --env-file config.env up -d
 ```
@@ -128,6 +127,17 @@ $ jupyter notebook \
   --port=8888 \
   --NotebookApp.port_retries=0
 ```
+
+After the notebook is started you need to load up picatrix using the code cell:
+
+```python
+from picatrix import notebook_init
+notebook_init.init()
+```
+
+*This also works if you want to connect to the hosted colab runtime. There you
+can simply add a cell with `!pip install --upgrade picatrix` and you should
+be able to start using picatrix.*
 
 ## Confirm Installation
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -26,7 +26,7 @@ By default the /tmp folder on your host will be mapped into a `data` folder
 on the docker container. If you want to change that and point to another
 folder on your system, edit the file `docker-latest.yml` and change the
 path `/tmp` to a folder of your choosing (just remember that the folder needs to
-be writable by `any` if you are running a Linux based host).
+be writable by uid=1000 and/or gid=1000 if you are running a Linux based host).
 
 For instance if you are running this on a Windows system, then you will
 need to change the `/tmp/` to something like `C:\My Folder\Where I store`.
@@ -76,6 +76,9 @@ To upgrade the container using the latest build, you can run:
 ```shell
 $ sudo docker pull us-docker.pkg.dev/osdfir-registry/picatrix/picatrix:latest
 ```
+
+*or if you are using Docker desktop you can find the docker image, click
+on the three dots and select pull*
 
 After updating the image the container needs to be recreated
 


### PR DESCRIPTION
Minor changes to the docker file to make it use a slimmer image, as well as some optimization inside the dockerfile itself, grouping together commands, reducing the amount of dependencies that are installed, etc.

Size of the old docker build (latest) 567 Mb
Size of the current docker build: 490 Mb

Looking at an older build: https://github.com/google/picatrix/pull/25/checks?check_run_id=1408088912

Took 1 min 49 seconds to setup infrastructure in the old GH actions/workflow, which takes now 1 min 18 seconds (seems to be consistent around the 1 minute 20 second mark, give or take)

Not a massive difference, but still a bit.