### PR TITLE
Added e2e tests to a cron schedule (daily checks)

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -2,6 +2,8 @@ name: picatrix-end-to-end
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  schedule:
+    - cron:  '30 11 * * *'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,5 +32,5 @@ EXPOSE ${JUPYTER_PORT}
 
 # Run jupyter.
 CMD jupyter notebook --port ${JUPYTER_PORT} \ 
-    --NotebookApp.allow_origin='https://colab.research.google.com' \ 
+    --NotebookApp.allow_origin_pat='https://colab.[a-z]+.google.com' \ 
     --NotebookApp.port_retries=0 --ip '*'


### PR DESCRIPTION
Added a daily run of the e2e tests, not just on PRs.

This is to make sure the code is WAI on an on-going basis.

(also small change to the way the jupyter shell is started)