### PR TITLE
Minor changes to install script and documentation.

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -12,7 +12,8 @@ Let's explore both methods:
 The easiest way to install picatrix is via docker. To use it, first
 [install docker](https://docs.docker.com/engine/install/).
 
-You also need to install `docker-compose`, please follow the instructions
+If you did not install the docker desktop app you may also need to install
+`docker-compose`, please follow the instructions
 [here](https://docs.docker.com/compose/install/) (the version that is often
 included in your source repo might be too old to properly setup the container).
 
@@ -41,9 +42,9 @@ It will also create a new file, called `docker/docker-tmp.yml` that defines
 the new location of the mapped data.
 
 If for some reasons the you are not able to create new notebooks, or see
-the example notebooks. Please edit the `docker/docker-tmp.yml` file and
-change the `~/picadata` line to a full path, eg. `/home/foobar/picadata`
-and run:
+the example notebooks (this may happen on a Mac OS X for instance).
+Please edit the `docker/docker-tmp.yml` file and change the `~/picadata`
+line to a full path, eg. `/home/foobar/picadata` and run:
 
 ```shell
 $ sudo docker container stop docker_picatrix_1

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -40,6 +40,16 @@ persistent storage for the picatrix container and fetch and start the container.
 It will also create a new file, called `docker/docker-tmp.yml` that defines
 the new location of the mapped data.
 
+If for some reasons the you are not able to create new notebooks, or see
+the example notebooks. Please edit the `docker/docker-tmp.yml` file and
+change the `~/picadata` line to a full path, eg. `/home/foobar/picadata`
+and run:
+
+```shell
+$ sudo docker container stop docker_picatrix_1
+$ sudo docker-compose -f docker/docker-tmp.yml up -d
+```
+
 ### Default Docker Script
 
 If you are not running on a Linux/Mac machine or want to customize the

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,6 @@ find ${HOME}/picadata -type f -exec chmod 660 {} \;
 cd docker
 cat docker-compose.yml| sed -e 's/\/tmp\//~\/picadata/g' > docker-tmp.yml
 sudo docker-compose -f docker-tmp.yml up -d
-rm docker-tmp.yml
 cd ..
 
 echo "Open http://localhost:8899/?token=picatrix in a browser window."


### PR DESCRIPTION
This PR makes minor adjustments to the `install.sh` script, as in it does not delete the temporary docker-compose file. In addition to that, a small troubleshooting guide is added to the installation documentation.

- [x] Appropriate changes to documentation is included
