### PR TITLE
Changed docker: Added ipywidgets and nbextensions support.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,10 +23,12 @@ COPY --chown=1000:1000 docker/jupyter_notebook_config.py /home/picatrix/.jupyter
 
 RUN pip install --upgrade pip setuptools wheel && \
     cd /home/picatrix/code && pip install -e . && \
-    pip install --upgrade ipywidgets jupyter_http_over_ws && \
+    pip install --upgrade ipywidgets jupyter_contrib_nbextensions jupyter_http_over_ws && \
     pip install scikit-learn matplotlib && \
     jupyter serverextension enable --py jupyter_http_over_ws && \
-    jupyter nbextension enable --py widgetsnbextension --sys-prefix
+    jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
+    jupyter contrib nbextension install --user && \
+    jupyter nbextensions_configurator enable --user
 
 WORKDIR /usr/local/src/picadata/
 EXPOSE 8899

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,9 +23,10 @@ COPY --chown=1000:1000 docker/jupyter_notebook_config.py /home/picatrix/.jupyter
 
 RUN pip install --upgrade pip setuptools wheel && \
     cd /home/picatrix/code && pip install -e . && \
-    pip install --upgrade jupyter_http_over_ws && \
+    pip install --upgrade ipywidgets jupyter_http_over_ws && \
     pip install scikit-learn matplotlib && \
-    jupyter serverextension enable --py jupyter_http_over_ws
+    jupyter serverextension enable --py jupyter_http_over_ws && \
+    jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 WORKDIR /usr/local/src/picadata/
 EXPOSE 8899


### PR DESCRIPTION
This is a simple change to the Dockerfile to enable ipywidgets support into the picatrix notebook. At this point no widgets are added, just the support so that they can be used.

This also add in the jupyter_contrib_nbextensions (user contrib nbextensions) and the nbextensions config option into the notebook. It doesn't enable any extensions at this point, but allows the user to select which ones to enable/disable.