### PR TITLE
Make display_table with with colab

### DIFF
--- a/picatrix/helpers/table.py
+++ b/picatrix/helpers/table.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Defines helper functions to display tables or dataframes."""
-from typing import Tuple, Optional
+from typing import Tuple, Union, Optional
 
 import pandas
 import ipyaggrid
+
+try:
+  # 3rd party widgets do not work inside colab, we will use the
+  # built-in data table instead there.
+  from google.colab.data_table import DataTable
+except ImportError:
+  DataTable = None
 
 from picatrix.lib import framework
 
@@ -26,8 +33,12 @@ DEFAULT_COLUMNS_HIDE = ('_type', '_id', '__ts_emojis', '_index')
 @framework.picatrix_helper
 def display_table(
     data_frame: pandas.DataFrame,
-    hide_columns: Optional[Tuple[str]] = None) -> ipyaggrid.grid.Grid:
+    hide_columns: Optional[Tuple[str]] = None) -> Union[
+        ipyaggrid.grid.Grid, DataTable]:
   """Display a dataframe interactively with a toolbar."""
+  if DataTable:
+    return DataTable(data_frame, include_index=False)
+
   column_defs = []
 
   if hide_columns is None:


### PR DESCRIPTION
This PR adds support for colab into the `display_table` helper.

- [x] Unit tests added
- [x] ~End-to-end tests added~
- [x] Appropriate changes to documentation is included
- [x] ~If additional dependencies are needed, are they added into dependency files.~
