### PR TITLE
Add Picatrix namespaces

### DIFF
--- a/picatrix/__init__.py
+++ b/picatrix/__init__.py
@@ -11,3 +11,107 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Sets up Picatrix environment."""
+
+from typing import Optional, Text, Tuple
+
+from .lib.namespace import (
+    FeatureContext,
+    FeatureNamespace,
+    Function,
+    RootContext,
+    RootNamespace,
+)
+
+px = RootNamespace(
+    "px", """Picatrix root namespace.
+
+    Features can be accessed as `px.{feature_name}`, e.g. `px.timesketch`.
+
+    Try:
+    * `px.search(\"keyword\")` to search features by keyword.
+    * `px?` or `px.{feature_name}?` for help.
+    """)
+ctx = RootContext(
+    "ctx", """Picatrix root context, holds all runtime parameters.
+
+    To check runtime parameters of a certain feature, try `ctx.{feature_name}`,
+    e.g. `ctx.timesketch.to_frame(with_values=True).
+
+    Try:
+    * `ctx.search(\"keyword\")` to search parameters by keyword
+    * `ctx?` or `ctx.{feature_name}?` for help.
+    """)
+
+
+def new_namespace(
+    name: Text,
+    namespace_docstring: Optional[Text] = None,
+    context_docstring: Optional[Text] = None,
+) -> Tuple[FeatureNamespace, FeatureContext]:
+  """Creates new Picatrix namespace and context for the feature.
+
+  Newly registered feature will be available as:
+  * `px.{name}` for functionalities,
+  * `ctx.{name}` for runtime parameters, i.e. context.
+
+  Args:
+    name: new namespaces name
+    namespace_docstring: custom docstring for the namespace
+        if None, "`px.{name}` contains all Picatrix features of {name}"
+    context_docstring: custom docstring for the context,
+        if None, "`ctx.{name}` contains all Picatrix context for {name}"
+
+  Returns:
+    Tuple[FeatureNamespace, FeatureContext]: new namespace and context.
+
+  Raises:
+    NamespaceKeyExistsError: when namespace already exists
+    NamespaceKeyError: when name is invalid, e.g. isn't Python identifier
+  """
+  return (
+      px.add_namespace(name, docstring=namespace_docstring),
+      ctx.add_namespace(name, docstring=context_docstring))
+
+
+def new_line_magic(func: Function, name: Optional[Text] = None):
+  """Adds new line magic to Picatrix namespace.
+
+  Newly registered magic will be available as:
+  * `%{name}` IPython line magic
+  * `px.magic.{name}` function
+
+  Args:
+    func: function to be made into magic
+    name: optional custom magic name, if None function name will be used
+
+  Raises:
+    NamespaceKeyExistsError: when required key already exists
+    NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    MagicParsingError: when provided function is an invalid magic
+  """
+  px.add_line_magic(func, name)
+
+
+def new_cell_magic(func: Function, name: Optional[Text] = None):
+  """Adds new cell magic to Picatrix namespace.
+
+  Newly registered magic will be available as:
+  * `%%{name}` IPython cell magic
+  * `px.magic.{name}` function
+
+  Args:
+    func: function to be made into magic
+    name: optional custom magic name, if None function name will be used
+
+  Raises:
+    NamespaceKeyExistsError: when required key already exists
+    NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    MagicParsingError: when provided function is an invalid magic
+  """
+  px.add_cell_magic(func, name)
+
+
+# shouldn't be exported
+del Optional, Text, Tuple  # type: ignore
+del FeatureContext, FeatureNamespace, Function, RootContext, RootNamespace,

--- a/picatrix/lib/ipython.py
+++ b/picatrix/lib/ipython.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# type: ignore
+"""Helper function for Picatrix IPython magic handling.
+
+This module exists mostly because of IPython non-strict type checking which
+annoys pyright. Type checking is disabled for this module so tread lightly.
+"""
+
+from typing import Any, Callable, Text, Union
+
+from IPython import get_ipython
+from IPython.core.interactiveshell import InteractiveShell
+
+
+def add_line_magic(name: Text, magic: Callable[..., Any]):
+  """Adds new IPython line magic (`%magic`)."""
+  ip: Union[InteractiveShell, None] = get_ipython()
+  if not ip:
+    return
+  ip.register_magic_function(magic, magic_kind="line", magic_name=name)
+
+
+def add_cell_magic(name: Text, magic: Callable[..., Any]):
+  """Adds new IPython line magic (`%%magic`)."""
+  ip: Union[InteractiveShell, None] = get_ipython()
+  if not ip:
+    return
+  ip.register_magic_function(magic, magic_kind="cell", magic_name=name)
+
+
+def delete_magic(name: Text):
+  """Deletes IPython magic based on name."""
+  ip: Union[InteractiveShell, None] = get_ipython()
+  if not ip:
+    return
+
+  line_magics = ip.magics_manager.magics.get("line", {})
+  if name in line_magics:
+    _ = ip.magics_manager.magics["line"].pop(name)
+  cell_magics = ip.magics_manager.magics.get("cell", {})
+  if name in cell_magics:
+    _ = ip.magics_manager.magics["cell"].pop(name)

--- a/picatrix/lib/namespace.py
+++ b/picatrix/lib/namespace.py
@@ -1,0 +1,381 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Types and functions defining Picatrix namespacing."""
+
+from difflib import get_close_matches
+from inspect import cleandoc
+from types import SimpleNamespace
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Text,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+import pandas
+
+from .error import Error
+from .ipython import add_cell_magic, add_line_magic, delete_magic
+from .magic import Magic, MagicType
+
+
+class NamespaceKeyError(Error, KeyError):
+  """Raised when Namespace attempted to operate on invalid key."""
+
+
+class NamespaceKeyExistsError(NamespaceKeyError):
+  """Raised when add operation was called on already existing key."""
+
+
+class NamespaceKeyMissingError(NamespaceKeyError):
+  """Raised when non-existing key is attempted to be accessed in a Namespace."""
+
+  def __init__(self, key: Text, other_keys: Iterable[Text]):
+    matches = get_close_matches(key, other_keys, 1)
+    if not matches:
+      super().__init__(f"{key} does not exist")
+    else:
+      super().__init__(
+          f"{key} does not exist; "
+          f"did you mean \"{matches[0]}\"")
+
+
+A = TypeVar("A")  # pylint: disable=invalid-name
+
+
+def _join_key(*args: Text):
+  return ".".join(args)
+
+
+def _as_df_record(name: Text, item: Any, with_doc: bool,
+                  with_values: bool) -> Dict[Text, Text]:
+  """Create a record compatible with pandas.DataFrame.from_records func.
+
+  Args:
+    name: human readable name of the item
+    item: item to be translated into the row
+    with_doc: if True, add whole docstring as a column; 1st line only otherwise
+
+  Returns:
+    Dict[Text, Text]: dictionary compatible with pandas.DataFrame.from_records
+  """
+  typ = "Namespace" if isinstance(item, Namespace) else str(type(item))
+  doc = str(item.__doc__) if item.__doc__ else ""
+  desc, *_ = doc.split("\n")
+
+  record = {
+      "Name": name,
+      "Type": typ,
+      "Description": desc,
+  }
+
+  if with_doc:
+    record["Docstring"] = doc
+  if with_values:
+    record["Value"] = str(item)  # type: ignore
+
+  return record
+
+
+class Namespace(SimpleNamespace, Generic[A]):
+  """Key-value type of structure with items accessible as attributes."""
+
+  name: Text
+  __dict__: Dict[Text, A]
+
+  def __init__(self, name: Text, docstring: Text, **kwargs: A):
+    super().__init__(**kwargs)
+    self.__doc__ = cleandoc(docstring)
+    self.name = name
+
+  def __setattr__(self, key: Text, value: A):
+    if not key.isidentifier():
+      raise NamespaceKeyError(
+          f"\"{key}\" isn't valid Python identifier, see: "
+          "https://docs.python.org/3/reference/"
+          "lexical_analysis.html#identifiers")
+    elif key in self:
+      raise NamespaceKeyExistsError(
+          f"\"{key}\" already exists; remove it "
+          "first with `del` operator, "
+          f"e.g. `del ns[\"{key}\"]`")
+    else:
+      super().__setattr__(key, value)
+
+  def __getattr__(self, key: Text) -> A:
+    if key in self:
+      return super().__getattr__(key)
+    else:
+      raise NamespaceKeyMissingError(key, self.keys())
+
+  def __delattr__(self, key: Text):
+    if key in self:
+      return super().__delattr__(key)
+    else:
+      raise NamespaceKeyMissingError(key, self.keys())
+
+  def __iter__(self) -> Iterator[Text]:
+    return iter(self.__dict__)
+
+  def __contains__(self, key: Text):
+    return self.__dict__.__contains__(key)
+
+  def keys(self) -> Iterator[Text]:
+    """Iterator over all of the keys in the namespace."""
+    return iter(self.__dict__.keys())
+
+  def values(self) -> Iterator[A]:
+    """Iterator over all of the values in the namespace."""
+    return iter(self.__dict__.values())
+
+  def items(self) -> Iterator[Tuple[Text, A]]:
+    """Iterator over all of the key-value pairs in the namespace."""
+    for key, value in self.__dict__.items():
+      yield (key, value)
+
+  def as_records(self,
+                 with_doc: bool = False,
+                 with_values: bool = False) -> List[Dict[Text, Text]]:
+    """Make into records to be used with pandas.DataFrame.from_records func."""
+    records = [_as_df_record(self.name, self, with_doc, False)]
+    for key, value in self.items():
+      if key == "name" or key.startswith("_"):
+        continue
+
+      if isinstance(value, Namespace):
+        records.extend(value.as_records(with_doc, with_values))
+      else:
+        records.append(
+            _as_df_record(
+                _join_key(self.name, key), value, with_doc, with_values))
+    return records
+
+  def to_frame(
+      self,
+      with_doc: bool = False,
+      with_values: bool = False) -> pandas.DataFrame:
+    """Make namespace into pandas.DataFrame."""
+    return pandas.DataFrame.from_records(  # type: ignore
+        self.as_records(with_doc, with_values))
+
+  def search(self, keyword: Text) -> pandas.DataFrame:
+    """Search namespace for elements containing keyword."""
+    df = self.to_frame(with_doc=True)
+    return df[df.Name.str.contains(keyword) |  # type: ignore
+              df.Docstring.str.contains(keyword)]  # type: ignore
+
+  def _add(self, key: Text, value: A):
+    """Adds a new value under the key.
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    """
+    setattr(self, key, value)
+
+  def get(self, key: Text, default: A) -> A:
+    """Return the value for key if key is in the namespace, else default."""
+    if key in self:
+      return getattr(self, key)
+    else:
+      return default
+
+  def delete(self, key: Text):
+    """Deletes a key from the namespace."""
+    self.__delattr__(key)
+
+
+Function = Callable[..., Any]
+"""Type representation of a function supported by Picatrix."""
+
+
+class MagicNamespace(Namespace[Function]):
+  """Namespace hosting IPython magics."""
+
+  def __delattr__(self, key: Text):
+    super().__delattr__(key)
+    delete_magic(key)
+
+  def add_line_magic(self, func: Function, name: Optional[Text] = None):
+    """Adds new line magic (`%magic`) to the namespace.
+
+    Args:
+      func: function to be made into magic
+      name: optional custom magic name, if None function name will be used
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+      MagicParsingError: when provided function is an invalid magic
+    """
+    name = name if name else func.__name__
+
+    magic = Magic.wrap(MagicType.LINE, func, name=name)
+    self._add(name, magic.func)
+
+    add_line_magic(name, magic)
+
+  def add_cell_magic(self, func: Function, name: Optional[Text] = None):
+    """Adds new cell magic (`%%magic`) to the namespace.
+
+    Args:
+      func: function to be made into magic
+      name: optional custom magic name, if None function name will be used
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+      MagicParsingError: when provided function is an invalid magic
+    """
+    name = name if name else func.__name__
+
+    magic = Magic.wrap(MagicType.CELL, func, name=name)
+    self._add(name, magic.func)
+
+    add_cell_magic(name, magic)
+
+
+class FeatureNamespace(Namespace[Function]):
+  """Namespace hosting functionalities of the specific feature."""
+
+  def add_function(self, key: Text, func: Function):
+    """Adds a new function to the namespace.
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    """
+    self._add(key, func)
+
+
+class RootNamespace(Namespace[Union[FeatureNamespace, Function]]):
+  """Namespace hosting all Picatrix funcionalities."""
+
+  magic: MagicNamespace
+
+  def __init__(
+      self, name: Text, docstring: Text, **kwargs: Union[FeatureNamespace,
+                                                         Function]):
+    super().__init__(name, docstring, **kwargs)
+    self.magic = MagicNamespace(
+        _join_key(self.name, "magic"),
+        "Namespace holding all IPython magics registered by Picatrix.")
+
+  def add_function(self, key: Text, func: Function):
+    """Adds a new function to the namespace.
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    """
+    self._add(key, func)
+
+  def add_line_magic(self, func: Function, name: Optional[Text] = None):
+    """Adds new line magic (`%magic`) to the namespace.
+
+    Args:
+      func: function to be made into magic
+      name: optional custom magic name, if None function name will be used
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+      MagicParsingError: when provided function is an invalid magic
+    """
+    self.magic.add_line_magic(func, name)
+
+  def add_cell_magic(self, func: Function, name: Optional[Text] = None):
+    """Adds new cell magic (`%%magic`) to the namespace.
+
+    Args:
+      func: function to be made into magic
+      name: optional custom magic name, if None function name will be used
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+      MagicParsingError: when provided function is an invalid magic
+    """
+    self.magic.add_cell_magic(func, name)
+
+  def add_namespace(
+      self, name: Text, docstring: Optional[Text] = None) -> FeatureNamespace:
+    """Adds a new namespace to the root namespace.
+
+    Args:
+      name: name of the new namespace
+      docstring: optional docstring for the new namespace
+
+    Returns:
+      new namespace
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    """
+    key = _join_key(self.name, name)
+    if not docstring:
+      docstring = f"`{key}` contains all Picatrix features of {name}"
+
+    ns = FeatureNamespace(name=key, docstring=docstring)
+    self._add(key, ns)
+    return ns
+
+
+class FeatureContext(Namespace[Any]):
+  """Namespace hosting runtime parameters of the specific feature."""
+
+  def add(self, key: Text, value: Any):
+    """Adds a new value under the key.
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    """
+    self._add(key, value)
+
+
+class RootContext(Namespace[FeatureContext]):
+  """Namespace hosting all Picatrix runtime parameters, i.e. context."""
+
+  def add_namespace(
+      self, name: Text, docstring: Optional[Text] = None) -> FeatureContext:
+    """Adds a new context to the root context.
+
+    Args:
+      name: name of the new subcontext
+      docstring: optional docstring for the new subcontext
+
+    Returns:
+      new subcontext
+
+    Raises:
+      NamespaceKeyExistsError: when required key already exists
+      NamespaceKeyError: when key is invalid, e.g. isn't Python identifier
+    """
+    key = _join_key(self.name, name)
+    if not docstring:
+      docstring = f"`{key}` contains all Picatrix context for {name}"
+
+    ctx = FeatureContext(name=key, docstring=docstring)
+    self._add(key, ctx)
+    return ctx

--- a/picatrix/lib/namespace_test.py
+++ b/picatrix/lib/namespace_test.py
@@ -1,0 +1,109 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# type: ignore
+# pylint: disable=W0212
+"""Test for Picatrix namespacing."""
+
+from typing import Union
+
+import pandas as pd
+import pytest
+
+from .namespace import Namespace, NamespaceKeyError
+
+
+def test_invalid_key():
+  """Test if namespace throws an error on invalid key names."""
+  n = Namespace[int](name="n", docstring="Example namespace")
+  with pytest.raises(NamespaceKeyError):
+    n._add("1aa", 1)
+
+
+def test_similar_key():
+  """Test if namespace throws an  helpful error on typos."""
+  n = Namespace[int](name="n", docstring="Example namespace")
+  n._add("apple", 1)
+  n._add("orange", 2)
+  n._add("carrot", 3)
+
+  with pytest.raises(NamespaceKeyError) as exc:
+    _ = n.aple
+
+  assert "did you mean \"apple\"" in str(exc)
+
+
+def test_to_frame():
+  """Test namespaces .to_frame functionality for nested namespaces."""
+  n = Namespace[Union[int, Namespace[int]]](
+      name="n", docstring="Example namespace")
+  n._add("apple", 1)
+  n._add("orange", 2)
+  n._add("carrot", 3)
+  n._add("nn", Namespace[int](name="n.nn", docstring="Nested namespace"))
+  n.nn._add("dog", 11)
+  n._add("tomato", 4)
+
+  a = 1
+  inttyp = str(type(a))
+  intdoc = a.__doc__
+  intdesc, *_ = intdoc.split("\n")
+
+  want = pd.DataFrame.from_records(
+      [
+          {
+              "Name": "n",
+              "Type": "Namespace",
+              "Description": "Example namespace",
+              "Docstring": "Example namespace",
+          },
+          {
+              "Name": "n.apple",
+              "Type": inttyp,
+              "Description": intdesc,
+              "Docstring": intdoc,
+          },
+          {
+              "Name": "n.orange",
+              "Type": inttyp,
+              "Description": intdesc,
+              "Docstring": intdoc,
+          },
+          {
+              "Name": "n.carrot",
+              "Type": inttyp,
+              "Description": intdesc,
+              "Docstring": intdoc,
+          },
+          {
+              "Name": "n.nn",
+              "Type": "Namespace",
+              "Description": "Nested namespace",
+              "Docstring": "Nested namespace",
+          },
+          {
+              "Name": "n.nn.dog",
+              "Type": inttyp,
+              "Description": intdesc,
+              "Docstring": intdoc,
+          },
+          {
+              "Name": "n.tomato",
+              "Type": inttyp,
+              "Description": intdesc,
+              "Docstring": intdoc,
+          },
+      ])
+  got = n.to_frame(with_doc=True)
+  assert want.equals(got)

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This is the setup file for the project."""
-from __future__ import unicode_literals
+from typing import List, Text
 
 from setuptools import find_packages, setup
 
-from picatrix import version
 
-
-def from_file(name):
+def from_file(name: Text) -> List[Text]:
   """Read dependencies from requirements.txt file."""
   with open(name, "r", encoding="utf-8") as f:
     return f.read().splitlines()
@@ -32,7 +30,7 @@ long_description = (
 
 setup(
     name="picatrix",
-    version=version.get_version(),
+    version="20210519",
     description="Picatrix IPython Helpers",
     long_description=long_description,
     license="Apache License, Version 2.0",


### PR DESCRIPTION
After this change new Picatrix feature can be registered using `picatrix.new_namespace` function.

After registration new subnamespaces will be created in `picatrix.px` (functionalities) and `picatrix.lib.ctx` (runtime parameters or open clients) singletons. Those can be later used by end-user for feature discovery, e.g. picatrix.px.search("timesketch").

Magics can be registered using `picatrix.new_line_magic` and `picatrix.new_cell_magic`. They will be registered in Picatrix and added to `picatrix.px.magic` namespace.
