### PR TITLE
DataFrame accessors first-class support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 			// Update 'VARIANT' to pick a Python version: 3, 3.9, 3.8, 3.7, 3.6.
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.7",
+			"VARIANT": "3.9",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}
@@ -29,12 +29,13 @@
 		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
 		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python",
-		"ms-python.vscode-pylance"
+		"ms-python.vscode-pylance",
+		"elagil.pre-commit-helper"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,11 +7,11 @@ env:
   LC_ALL: "C.UTF-8"
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
-        python-version: [3.7, 3.8]
+        os: [ubuntu-22.04, macos-latest]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: "v0.31.0"
+    rev: "v0.32.0"
     hooks:
       - id: yapf
         args: ["--style=.style.yapf", "--parallel", "--in-place"]
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/picatrix/magics/timesketch.py
+++ b/picatrix/magics/timesketch.py
@@ -397,14 +397,14 @@ def timesketch_add_manual_event(
             'Unable to convert date string, is it really in ISO 8601 format?')
         return {}
     try:
-      elements.CopyFromString(date_string)
+      elements.CopyFromStringRFC822(date_string)
     except ValueError:
       try:
         elements.CopyFromStringRFC1123(date_string)
       except ValueError:
         logger.error(
-            'Unable to convert date string, needs to be in ISO 8601, 1123 or '
-            'in the format YYYY-MM-DD hh:mm:ss.######[+-]##:##')
+            'Unable to convert date string, needs to be in ISO 8601, RFC 822'
+            ' or 1123')
         return {}
     date = elements.CopyToDateTimeStringISO8601()
 

--- a/picatrix/modules/formats.py
+++ b/picatrix/modules/formats.py
@@ -1,0 +1,87 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions and magics for handling popular data formats."""
+
+import json as _json
+from io import StringIO
+from typing import Any, Dict, Text
+
+import pandas
+
+from picatrix import new_cell_magic
+
+
+@new_cell_magic
+def text(cell: Text) -> Text:
+  """Ingest the cell content as raw text without evaluating escape codes.
+  
+  Args:
+    cell: text to be loaded
+
+  Returns:
+    cell text
+  """
+  return cell
+
+
+@new_cell_magic
+def csv(
+    cell: Text,
+    sep: Text = ",",
+    quotechar: Text = "\"",
+    doublequote: bool = True,
+    escapechar: Text = "\\",
+) -> pandas.DataFrame:
+  """Parse cell content as a CSV data and create a pandas DataFrame.
+  
+  The function uses pandas.read_csv function to parse the text:
+  https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+
+  Args:
+    cell: text to be parsed as CSV
+    sep: Delimiter to use
+    quotechar: The character used to denote the start and end of a 
+      quoted item. Quoted items can include the delimiter and it 
+      will be ignored.
+    doublequote: a flag determining whether or not to interpret two 
+      consecutive quotechar elements INSIDE a field as a single 
+      quotechar element.
+    escapechar: One-character string used to escape other characters.
+
+  Returns:
+    pandas DataFrame constructed from the CSV.
+  """
+  return pandas.read_csv( # type: ignore
+      StringIO(cell),
+      sep=sep,
+      quotechar=quotechar,
+      doublequote=doublequote,
+      escapechar=escapechar,
+  )
+
+
+@new_cell_magic
+def json(cell: Text) -> Dict[Text, Any]:
+  """Parse cell content as a JSON object and create a Python dict.
+
+  The function uses json.load function to parse the text:
+  https://docs.python.org/3/library/json.html#json.load
+  
+  Args:
+    cell: text to be parsed as JSON
+    
+  Returns:
+    a Python dict construced from the JSON
+  """
+  return _json.loads(cell)

--- a/requirements_runtime.txt
+++ b/requirements_runtime.txt
@@ -6,6 +6,4 @@ jupyter-contrib-nbextensions>=0.5.1
 jupyter-http-over-ws>=0.0.8
 jupyter>=1.0.0
 matplotlib>=2.2.0
-numpy>=1.19.0
-pandas>=1.1.3
 scikit-learn>=1.0


### PR DESCRIPTION
This PR adds DataFrame accessors as a first-class functionality in Picatrix.

Accessors can now be added in a following way:

```python
from picatrix import new_accessor_namespace

accessor = new_accessor_namespace("example")

@accessor.add_accessor(validator: lambda df: "email" in df.columns)
def bulk_email(df, send_as_bcc = False):
  ...
```

And later used as following if the validator matches the content of a DataFrame:
```
df.example.bulk_email(send_as_bcc=True)
```

---

I also used the opportunity to clean up the configuration a little as many libraries and tools dropped support for Python 3.7 since the last PR.